### PR TITLE
Fixed PyYAML (by default Colab installs 3.13)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ faiss-gpu==1.6.5
 kapre==0.3.5
 librosa
 click
-pyyaml
+pyyaml==5.4.1
 numpy
 matplotlib
 wavio


### PR DESCRIPTION
By default, PyYAML-3.13 is sometimes used in the default Colab environment (and thus it outputs a `dump_all() got an unexpected keyword argument 'sort_keys'` error). This should fix the issue